### PR TITLE
Add version 3.20.4 to shell-version

### DIFF
--- a/alt-tab-workspace@kwalo.net/metadata.json
+++ b/alt-tab-workspace@kwalo.net/metadata.json
@@ -9,10 +9,11 @@
     "3.14.3",
     "3.16",
     "3.18",
+    "3.20.4",
     "3.22.3",
     "3.24"
   ], 
   "url": "https://github.com/kwalo/gnome-shell-alt-tab-workspace", 
   "uuid": "alt-tab-workspace@kwalo.net", 
-  "version": 10
+  "version": 11
 }


### PR DESCRIPTION
I've tested this extension for a week on Gnome 3.20.4 and it works great.