### PR TITLE
Add version 3.28 to shell-version list

### DIFF
--- a/alt-tab-workspace@kwalo.net/metadata.json
+++ b/alt-tab-workspace@kwalo.net/metadata.json
@@ -11,7 +11,8 @@
     "3.18",
     "3.20.4",
     "3.22.3",
-    "3.24"
+    "3.24",
+    "3.28"
   ], 
   "url": "https://github.com/kwalo/gnome-shell-alt-tab-workspace", 
   "uuid": "alt-tab-workspace@kwalo.net", 


### PR DESCRIPTION
Extension works fine with version 3.28.2, no errors emitted.